### PR TITLE
Feature/handle array of paths or html strings

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,7 +6,10 @@ const getFilePaths = require('../lib/getFilePaths.js');
 const getElementsFromFile = require('../lib/getElementsFromFile.js');
 const getDocumentFromFilePathOrHtmlString = require('../lib/getDocumentFromFilePathOrHtmlString.js');
 const getSelectedElementsFromSelectedFiles = require('../lib/getSelectedElementsFromSelectedFiles.js');
-const getTocData = require('../index');
+const {
+  getTocDataFromDir,
+  getTocDataFromArrayOfHtmlPathsOrStrings,
+} = require('../index');
 
 const testHTMLFilenames = [
   'page001.html',
@@ -259,13 +262,13 @@ describe('getDocumentFromFilePathOrHtmlString', () => {
 
 // 4. test implementation
 
-describe('getTocData', () => {
+describe('getTocDataFromDir', () => {
   test('should return the flattened array with objects for each element', async () => {
-    const actual = await getTocData('__tests__/fixtures');
+    const actual = await getTocDataFromDir('__tests__/fixtures');
     expect(actual).toHaveLength(13);
   });
   test('should return the data sorted by fileID and then level', async () => {
-    const data = await getTocData('__tests__/fixtures');
+    const data = await getTocDataFromDir('__tests__/fixtures');
     const mappedHeadingText = arr => arr.map(el => el.text);
     const actual = mappedHeadingText(data);
     const expected = [
@@ -287,4 +290,19 @@ describe('getTocData', () => {
   });
 });
 
-// TODO: include an actual template generator function for CLI usage, but export getTocData and templateGen separately
+describe('getTocDataFromArrayOfHtmlPathsOrStrings', () => {
+  const filePath = path.join(__dirname, 'fixtures', testHTMLFilenames[0]);
+  test('should return data from an array of html strings', async () => {
+    const readFile = promisify(fs.readFile);
+    const buffer = await readFile(filePath, 'UTF-8');
+    const htmlArray = [buffer.toString()];
+    const mappedHeadingText = arr => arr.map(el => el.text);
+    const expected = ['First Heading', 'Second Heading', 'Third Heading'];
+    const actualData = await getTocDataFromArrayOfHtmlPathsOrStrings(htmlArray);
+    const actual = mappedHeadingText(actualData);
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+// TODO: include an actual template generator function for CLI usage, but export getTocDataFromDir and templateGen separately

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,7 +1,10 @@
 const path = require('path');
+const fs = require('fs');
+const { promisify } = require('util');
 const jsdom = require('jsdom');
 const getFilePaths = require('../lib/getFilePaths.js');
 const getElementsFromFile = require('../lib/getElementsFromFile.js');
+const getDocumentFromFilePathOrHtmlString = require('../lib/getDocumentFromFilePathOrHtmlString.js');
 const getSelectedElementsFromSelectedFiles = require('../lib/getSelectedElementsFromSelectedFiles.js');
 const getTocData = require('../index');
 
@@ -229,10 +232,30 @@ describe('getSelectedElementsFromSelectedFiles', () => {
 });
 
 // 3.
-// ? probably not necessary, better to work with arrays in this case; preventing duplicate IDs is on the user
-// accepts an array of dom (?) elements and returns a map
-// the id of each element should be the key
-// should throw an error if it encounters duplicate IDs
+
+// accepts either a path to an html file or a string of html and returns a jsom document
+
+describe('getDocumentFromFilePathOrHtmlString', () => {
+  const { JSDOM } = jsdom;
+  const filePath = path.join(__dirname, 'fixtures', testHTMLFilenames[0]);
+
+  test('should accept a path to an html file and return a jsdom document', async () => {
+    const dom = await JSDOM.fromFile(filePath);
+    const expected = dom.window.document;
+    const actual = await getDocumentFromFilePathOrHtmlString(filePath);
+    expect(actual).toEqual(expected);
+  });
+
+  test('should accept a string of html and return a jsdom document', async () => {
+    const dom = await JSDOM.fromFile(filePath);
+    const expected = dom.window.document;
+    const readFile = promisify(fs.readFile);
+    const buffer = await readFile(filePath, 'UTF-8');
+    const htmlString = buffer.toString();
+    const actual = await getDocumentFromFilePathOrHtmlString(htmlString);
+    expect(actual).toEqual(expected);
+  });
+});
 
 // 4. test implementation
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const defaultProps = {
   extensions: ['html'],
   headings: ['h1', 'h2', 'h3', 'h4', 'h5'],
 };
-module.exports = async (
+const getTocDataFromDir = async (
   pagesDir,
   extensions = defaultProps.extensions,
   headings = defaultProps.headings
@@ -27,3 +27,21 @@ module.exports = async (
     throw new Error(e);
   }
 };
+
+const getTocDataFromArrayOfHtmlPathsOrStrings = async (
+  arr,
+  levels = defaultProps.headings.length
+) => {
+  const selectedHeadings = defaultProps.headings.slice(0, levels);
+  try {
+    const data = await getSelectedElementsFromSelectedFiles(
+      arr,
+      selectedHeadings
+    );
+    return data;
+  } catch (e) {
+    throw new Error(e);
+  }
+};
+
+module.exports = { getTocDataFromDir, getTocDataFromArrayOfHtmlPathsOrStrings };

--- a/lib/getDocumentFromFilePathOrHtmlString.js
+++ b/lib/getDocumentFromFilePathOrHtmlString.js
@@ -1,0 +1,16 @@
+const jsdom = require('jsdom');
+
+const { JSDOM } = jsdom;
+
+module.exports = async filePathOrHtmlString => {
+  const isHtmlString = /<("[^"]*"|'[^']*'|[^'">])*>/.test(filePathOrHtmlString);
+  try {
+    const dom = isHtmlString
+      ? await new JSDOM(filePathOrHtmlString)
+      : await JSDOM.fromFile(filePathOrHtmlString);
+    const { document } = dom.window;
+    return document;
+  } catch (e) {
+    throw new Error(e);
+  }
+};

--- a/lib/getElementsFromDocument.js
+++ b/lib/getElementsFromDocument.js
@@ -1,0 +1,29 @@
+module.exports = (document, tagnames = []) => {
+  try {
+    const selectors = [].concat(tagnames); // ensures it's always an array even if the user passes a string value
+
+    const isIDPrefix = selector =>
+      selector.indexOf('#') === 0 &&
+      selector.indexOf('-') === selector.length - 1;
+
+    const selectorOrIDPrefix = selector =>
+      isIDPrefix(selector) ? `[id^=${selector.slice(1)}]` : selector;
+
+    const getLevel = selector =>
+      isIDPrefix(selector)
+        ? selector.split('-').pop() // to use this feature, the selector id must be in the format of /#+[\w]+\-[\d]/
+        : selectors.indexOf(selector) + 1;
+
+    return selectors.reduce(
+      (acc, curr) => [
+        ...acc,
+        ...Array.from(document.querySelectorAll(selectorOrIDPrefix(curr))).map(
+          el => ({ el, level: getLevel(curr) })
+        ),
+      ],
+      []
+    );
+  } catch (e) {
+    throw new Error(e);
+  }
+};

--- a/lib/getElementsFromFile.js
+++ b/lib/getElementsFromFile.js
@@ -1,34 +1,11 @@
-const jsdom = require('jsdom');
-
-const { JSDOM } = jsdom;
+const getDocumentFromFilePathOrHtmlString = require('./getDocumentFromFilePathOrHtmlString.js');
+const getElementsFromDocument = require('./getElementsFromDocument.js');
 
 module.exports = async (htmlFile, tagnames = []) => {
   try {
-    const dom = await JSDOM.fromFile(htmlFile);
-    const { document } = dom.window;
-    const selectors = [].concat(tagnames); // ensures it's always an array even if the user passes a string value
-
-    const isIDPrefix = selector =>
-      selector.indexOf('#') === 0 &&
-      selector.indexOf('-') === selector.length - 1;
-
-    const selectorOrIDPrefix = selector =>
-      isIDPrefix(selector) ? `[id^=${selector.slice(1)}]` : selector;
-
-    const getLevel = selector =>
-      isIDPrefix(selector)
-        ? selector.split('-').pop() // to use this feature, the selector id must be in the format of /#+[\w]+\-[\d]/
-        : selectors.indexOf(selector) + 1;
-
-    return selectors.reduce(
-      (acc, curr) => [
-        ...acc,
-        ...Array.from(document.querySelectorAll(selectorOrIDPrefix(curr))).map(
-          el => ({ el, level: getLevel(curr) })
-        ),
-      ],
-      []
-    );
+    const document = await getDocumentFromFilePathOrHtmlString(htmlFile);
+    const elements = await getElementsFromDocument(document, tagnames);
+    return elements;
   } catch (e) {
     throw new Error(e);
   }

--- a/lib/getSelectedElementsFromSelectedFiles.js
+++ b/lib/getSelectedElementsFromSelectedFiles.js
@@ -2,16 +2,16 @@ const path = require('path');
 
 const getElementsFromFile = require('./getElementsFromFile.js');
 
-module.exports = async (filePaths, selectors) => {
+module.exports = async (htmlFiles, selectors) => {
   try {
-    const allPromises = filePaths.map(async (file, i) => {
+    const allPromises = htmlFiles.map(async (file, i) => {
       const fileElements = await getElementsFromFile(file, selectors);
       return fileElements.map(({ el, level }) => ({
         el,
         text: el.textContent,
         id: el.id,
         fileID: i,
-        page: path.basename(filePaths[i].split('.')[0]),
+        page: path.basename(htmlFiles[i].split('.')[0]),
         level,
       }));
     });


### PR DESCRIPTION
Refactor `getElementsFromFile.js`, creating a new function `getElementsFromDocument.js` for the non-async code as well as the new function `getDocumentFromFilePathOrHtmlString.js` to return the `jsdom` document objects from either a path to an `html` file or an `html` string.

Split `index.js` into 2 named exports that allow the user to use the API in two different ways, by either specifying the path to a directory (as one might with a CLI app), or by manually passing in an array of paths to `html` files or `html` strings (as one might with a Gulp plugin or within another node app).